### PR TITLE
adjustments for showing questionnaire_id and version in downloaded data

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -453,7 +453,7 @@ if __name__ == "__main__":
         "w+",
         result_df.loc[
             result_df["JSON"].notna(),
-            ["UUID", "SubjectId", "JSON", "AbsendeDatum", "ErhaltenDatum"],
+            ["UUID", "SubjectId", "QuestionnaireId", "Version", "JSON", "AbsendeDatum", "ErhaltenDatum"],
         ],
     )
 


### PR DESCRIPTION
After applying these changes the downloaded questionnaire responses will give information about the questionnaire id and version.